### PR TITLE
Update the URL to its temporary location

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4,7 +4,7 @@ Shortname: compression
 Level: none
 Status: w3c/CG-DRAFT
 Group: wicg
-ED: https://wicg.github.io/compression-streams/
+ED: https://ricea.github.io/compression/
 Editor: Canon Mukai, Google
 Editor: Adam Rice, Google
 Abstract:

--- a/index.html
+++ b/index.html
@@ -1214,8 +1214,8 @@ Possible extra rowspan handling
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version e86d5b1b47a216fa66165c234892adc259212183" name="generator">
-  <link href="https://wicg.github.io/compression-streams/" rel="canonical">
-  <meta content="02a8b101b05965546135ce6aed5648daa22d7850" name="document-revision">
+  <link href="https://ricea.github.io/compression/" rel="canonical">
+  <meta content="4d7901982358a3ccf612e12b39f43913dcef2070" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1466,7 +1466,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://wicg.github.io/compression-streams/">https://wicg.github.io/compression-streams/</a>
+     <dd><a class="u-url" href="https://ricea.github.io/compression/">https://ricea.github.io/compression/</a>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/ricea/compression-streams/issues/">GitHub</a>
      <dt class="editor">Editors:


### PR DESCRIPTION
This spec can temporarily be found at
https://ricea.github.io/compression/. Link to it there.